### PR TITLE
Remove private field JS so it works in Safari

### DIFF
--- a/bar-website/index.js
+++ b/bar-website/index.js
@@ -1,7 +1,7 @@
 class Bar {
-  barEndpoint = "http://localhost:3000/bar";
-
   constructor() {
+    this.barEndpoint = "http://localhost:3000/bar";
+
     $(document).ready(() => {
       this.verify();
     });

--- a/foo-website/index.js
+++ b/foo-website/index.js
@@ -1,7 +1,7 @@
 class Foo {
-  fooEndpoint = "http://localhost:3000/foo";
-
   constructor() {
+    this.fooEndpoint = "http://localhost:3000/foo";
+
     $(document).ready(() => {
       this.verify();
     });


### PR DESCRIPTION
Use private fields in our JS prevents the foo & bar websites from opening in Safari. Private fields aren't currently supported natively by Safari so just moving it to be a constructor field instead.