### PR TITLE
Upgrade Gradle to resolve JDK 14 build failures

### DIFF
--- a/spring/gradle/wrapper/gradle-wrapper.properties
+++ b/spring/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
If you try to run `script/spring/start` when using JDK 14 you get the following error:

```
java.lang.NoClassDefFoundError: Could not initialize class org.codehaus.groovy.vmplugin.v7.Java7
```


According to https://github.com/gradle/gradle/issues/10248 we should upgrade the gradle version 