### PR TITLE
Change spring setup script to output message

### DIFF
--- a/script/spring/setup
+++ b/script/spring/setup
@@ -1,3 +1,2 @@
 #!/bin/bash
-cd spring
-./gradlew bootRun
+echo "No need to run any setup. Running 'script/spring/start' runs any setup scripts you need"


### PR DESCRIPTION
In the main README we mention

![image](https://user-images.githubusercontent.com/685034/91036617-922c0100-e5ff-11ea-8496-b0754f8811c1.png)

We then ask you to run `script/{your-framework}/start`. In the `spring` minicom the `start` command implements all the setup so we can skip a step. 

So to prevent any confusion from the candidate I've just modified the spring `setup` script to output a message saying they can just run `script/spring/start` instead.
