### PR TITLE
Correct ports for foo and bar

### DIFF
--- a/script/bar/start
+++ b/script/bar/start
@@ -2,7 +2,7 @@
 
 WWW_ROOT="./bar-website"
 LISTEN_HOST="127.0.0.1"
-LISTEN_PORT=8008
+LISTEN_PORT=8009
 
 echo "Serving $WWW_ROOT on http://$LISTEN_HOST:$LISTEN_PORT (^C to stop)."
 

--- a/script/bar/start.bat
+++ b/script/bar/start.bat
@@ -3,7 +3,7 @@
 setlocal
 set WWW_ROOT="./bar-website"
 set LISTEN_HOST="127.0.0.1"
-set LISTEN_PORT=8008
+set LISTEN_PORT=8009
 
 echo "Serving %WWW_ROOT% on http://%LISTEN_HOST%:%LISTEN_PORT% (^C to stop)."
 

--- a/script/foo/start
+++ b/script/foo/start
@@ -2,7 +2,7 @@
 
 WWW_ROOT="./foo-website"
 LISTEN_HOST="127.0.0.1"
-LISTEN_PORT=8009
+LISTEN_PORT=8008
 
 echo "Serving $WWW_ROOT on http://$LISTEN_HOST:$LISTEN_PORT (^C to stop)."
 

--- a/script/foo/start.bat
+++ b/script/foo/start.bat
@@ -3,7 +3,7 @@
 setlocal
 set WWW_ROOT="./foo-website"
 set LISTEN_HOST="127.0.0.1"
-set LISTEN_PORT=8009
+set LISTEN_PORT=8008
 
 echo "Serving %WWW_ROOT% on http://%LISTEN_HOST%:%LISTEN_PORT% (^C to stop)."
 


### PR DESCRIPTION
Readme: https://github.com/intercom/minicom-public#task

> This will get you the foo site running at http://127.0.0.1:8008, the bar interface running at http://127.0.0.1:8009 and a webserver running at http://127.0.0.1:3000.

swapping the ports for foo and bar to be based on the readme