### PR TITLE
Add descriptive error if no server found when starting foo or bar

### DIFF
--- a/script/bar/start
+++ b/script/bar/start
@@ -6,4 +6,9 @@ LISTEN_PORT=8009
 
 echo "Serving $WWW_ROOT on http://$LISTEN_HOST:$LISTEN_PORT (^C to stop)."
 
-ruby -run -e httpd $WWW_ROOT -p $LISTEN_PORT -- -c "CacheDisable on" || php -S "$LISTEN_HOST:$LISTEN_PORT" -t $WWW_ROOT || npx serve $WWW_ROOT -l $LISTEN_PORT || cd $WWW_ROOT && python3 -m http.server $LISTEN_PORT
+ruby -run -e httpd $WWW_ROOT -p $LISTEN_PORT -- -c "CacheDisable on" \
+|| php -S "$LISTEN_HOST:$LISTEN_PORT" -t $WWW_ROOT \
+|| npx serve $WWW_ROOT -l $LISTEN_PORT \
+|| cd $WWW_ROOT && python3 -m http.server $LISTEN_PORT \
+|| printf "\n=======================\nERROR: Bar Server not started\nIt appears you don't have the required dependencies to start the Bar server.\n\n1) Install the Node LTS from https://nodejs.org/\n2) Open a new terminal window\n3) Re-run this script again.\n=======================\n" >&2
+exit 1

--- a/script/bar/start.bat
+++ b/script/bar/start.bat
@@ -7,4 +7,33 @@ set LISTEN_PORT=8009
 
 echo "Serving %WWW_ROOT% on http://%LISTEN_HOST%:%LISTEN_PORT% (^C to stop)."
 
-ruby -run -e httpd %WWW_ROOT% -p %LISTEN_PORT% -- -c "CacheDisable on" || php -S "%LISTEN_HOST%:%LISTEN_PORT%" -t %WWW_ROOT% || npx serve %WWW_ROOT% -l %LISTEN_PORT% || cd %WWW_ROOT% && python3 -m http.server %LISTEN_PORT%
+for /f %%i in ('ruby --version') do set RUBY_VERSION=%%i
+for /f %%i in ('php -v') do set PHP_VERSION=%%i
+for /f %%i in ('npx --version') do set NPX_VERSION=%%i
+for /f %%i in ('python3 --version') do set PYTHON_VERSION=%%i
+
+IF /I "%RUBY_VERSION%" NEQ "" (
+    ruby -run -e httpd %WWW_ROOT% -p %LISTEN_PORT% -- -c "CacheDisable on"
+) ELSE IF /I "%PHP_VERSION%" NEQ "" (
+    php -S "%LISTEN_HOST%:%LISTEN_PORT%" -t %WWW_ROOT%
+) ELSE IF /I "%NPX_VERSION%" NEQ "" (
+    npx serve %WWW_ROOT% -l %LISTEN_PORT%
+) ELSE IF /I "%PYTHON_VERSION%" NEQ "" (
+    cd %WWW_ROOT% && python3 -m http.server %LISTEN_PORT%
+) ELSE (
+    echo.
+    echo.
+    echo ERROR: Bar Server not started
+    echo.
+    echo It appears you don't have the required dependencies to start the Bar server.
+    echo.
+    echo.
+    echo 1. Install the Node LTS from https://nodejs.org/
+    echo.
+    echo 2. Open a new terminal window
+    echo.
+    echo 3. Re-run this script again.
+    echo.
+    echo =======================
+    echo.
+)

--- a/script/foo/start
+++ b/script/foo/start
@@ -6,4 +6,9 @@ LISTEN_PORT=8008
 
 echo "Serving $WWW_ROOT on http://$LISTEN_HOST:$LISTEN_PORT (^C to stop)."
 
-ruby -run -e httpd $WWW_ROOT -p $LISTEN_PORT -- -c "CacheDisable on" || php -S "$LISTEN_HOST:$LISTEN_PORT" -t $WWW_ROOT || npx serve $WWW_ROOT -l $LISTEN_PORT || cd $WWW_ROOT && python3 -m http.server $LISTEN_PORT
+ruby -run -e httpd $WWW_ROOT -p $LISTEN_PORT -- -c "CacheDisable on" \
+|| php -S "$LISTEN_HOST:$LISTEN_PORT" -t $WWW_ROOT \
+|| npx serve $WWW_ROOT -l $LISTEN_PORT \
+|| cd $WWW_ROOT && python3 -m http.server $LISTEN_PORT \
+|| printf "\n=======================\nERROR: Foo Server not started\nIt appears you don't have the required dependencies to start the Foo server.\n\n1) Install the Node LTS from https://nodejs.org/\n2) Open a new terminal window\n3) Re-run this script again.\n=======================\n" >&2
+exit 1

--- a/script/foo/start.bat
+++ b/script/foo/start.bat
@@ -7,4 +7,33 @@ set LISTEN_PORT=8008
 
 echo "Serving %WWW_ROOT% on http://%LISTEN_HOST%:%LISTEN_PORT% (^C to stop)."
 
-ruby -run -e httpd %WWW_ROOT% -p %LISTEN_PORT% -- -c "CacheDisable on" || php -S "%LISTEN_HOST%:%LISTEN_PORT%" -t %WWW_ROOT% || npx serve %WWW_ROOT% -l %LISTEN_PORT% || cd %WWW_ROOT% && python3 -m http.server %LISTEN_PORT%
+for /f %%i in ('ruby --version') do set RUBY_VERSION=%%i
+for /f %%i in ('php -v') do set PHP_VERSION=%%i
+for /f %%i in ('npx --version') do set NPX_VERSION=%%i
+for /f %%i in ('python3 --version') do set PYTHON_VERSION=%%i
+
+IF /I "%RUBY_VERSION%" NEQ "" (
+    ruby -run -e httpd %WWW_ROOT% -p %LISTEN_PORT% -- -c "CacheDisable on"
+) ELSE IF /I "%PHP_VERSION%" NEQ "" (
+    php -S "%LISTEN_HOST%:%LISTEN_PORT%" -t %WWW_ROOT%
+) ELSE IF /I "%NPX_VERSION%" NEQ "" (
+    npx serve %WWW_ROOT% -l %LISTEN_PORT%
+) ELSE IF /I "%PYTHON_VERSION%" NEQ "" (
+    cd %WWW_ROOT% && python3 -m http.server %LISTEN_PORT%
+) ELSE (
+    echo.
+    echo.
+    echo ERROR: Foo Server not started
+    echo.
+    echo It appears you don't have the required dependencies to start the Foo server.
+    echo.
+    echo.
+    echo 1. Install the Node LTS from https://nodejs.org/
+    echo.
+    echo 2. Open a new terminal window
+    echo.
+    echo 3. Re-run this script again.
+    echo.
+    echo =======================
+    echo.
+)


### PR DESCRIPTION
If the user doesn't have ruby, php, node or python installed when trying to run the Foo or Bar server we output a descriptive error asking them to install Node.

![image](https://user-images.githubusercontent.com/685034/104738267-36dce580-573d-11eb-8f61-736889432143.png)
