### PR TITLE
Update Spring setup doc

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 18.18.2
+java temurin-11.0.27+6

--- a/spring/README.md
+++ b/spring/README.md
@@ -8,6 +8,10 @@ There's nothing to be done here for the interview set-up, but feel free to look 
 
 The start command runs any setup scripts you need.
 
+### Required
+- [Java 11 SDK](https://www.oracle.com/java/technologies/downloads/#java11) - please ensure to have JDK 11 properly installed in order to run the application.
+    - If you're using [asdf](https://asdf-vm.com/) to manage runtimes, simply run `asdf install java` from the root folder to get it installed.
+
 ## Starting the server
 
 From the project root run  `script/spring/start`


### PR DESCRIPTION
### Context
PR from a candidate going through the minicom Spring setup. As I had a more recent JDK version (17) in my environment, I faced an error when running the application since Gradle 6.5 doesn't support JDK 17:
```
Execution failed for task ':compileJava'.
> java.lang.IllegalAccessError: class org.gradle.internal.compiler.java.ClassNameCollector (in unnamed module @0x7d3eabb3) cannot access class com.sun.tools.javac.code.Symbol$TypeSymbol (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.code to unnamed module @0x7d3eabb3
```
### Main changes
- Add documentation around required JDK version


### Note
Unsure if there's a particular reason for sticking with Gadle `6.5` and Spring Boot `2.1.6`. In case there is, please consider this PR. Otherwise, please feel free to close this PR and consider [Upgrade Spring project with Spring Boot 3.5.0 and Gradle 8.5](https://github.com/intercom/minicom-public/pull/32) instead.
Thanks
